### PR TITLE
Fixed Discard Bug with Grouped Items + Substring Item Name issue

### DIFF
--- a/bfunc.py
+++ b/bfunc.py
@@ -136,7 +136,9 @@ async def callAPI(ctx, apiEmbed="", apiEmbedmsg=None, table=None, query=None, si
         #  collection.find(collection.find(filterDic)) does not work for he could not read
         # https://cdn.discordapp.com/attachments/663504216135958558/735695855667118080/New_Project_-_2020-07-22T231158.186.png
         records = list(collection.find(filterDic))
-
+    
+    #turn the query into a regex expression
+    r = re.compile(query)
     #restore the original query
     query = query.replace("\\", "")
     #sort elements by either the name, or the first element of the name list in case it is a list
@@ -146,8 +148,6 @@ async def callAPI(ctx, apiEmbed="", apiEmbedmsg=None, table=None, query=None, si
         else:  
             return elem['Name']
     
-    #turn the query into a regex expression
-    r = re.compile(query)
     #create collections to track needed changes to the records
     remove_grouper = [] #track all elements that need to be removes since they act as representative for a group of items
     faux_entries = [] #collection of temporary items that will act as database elements during the call
@@ -161,7 +161,9 @@ async def callAPI(ctx, apiEmbed="", apiEmbedmsg=None, table=None, query=None, si
             # remove it later
             remove_grouper.append(entry)
             # check if the query is more specific about a group element
+            print("Search: ", entry['Name'])
             newlist = list(filter(r.search, entry['Name']))
+            print("Filtered: ", newlist)
             """
             if the every element has been filtered out because of the code above then we know from the fact 
             that this was found in the search that the Grouper field had to have been matched, 
@@ -169,15 +171,12 @@ async def callAPI(ctx, apiEmbed="", apiEmbedmsg=None, table=None, query=None, si
             """
             if(newlist == list()):
                 newlist = entry['Name']
-            print("Filtered: ", newlist)
             # for every group element that needs to be considered, create a new element with just the name adjusted
             for name in newlist:
-                print("Name: ", name)
                 #copy the Group entry to get all relevant information about the item
                 faux_entry = entry.copy()
                 #change the name from the list to the specific element.
                 faux_entry["Name"]= name
-                print("Copy: ", faux_entry)
                 #add it to the tracker
                 faux_entries.append(faux_entry)
     # remove all group representatives


### PR DESCRIPTION
The grouped property gets properly cleared now when an item gets discarded
Items with similar names (Vicious Weapon, Vicious Weapon +1) no longer block each other